### PR TITLE
ci: scope push trigger to long-lived branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,13 @@ name: CI
 # `!tests/simulation_test.py`); otherwise CI has nothing to run.
 
 on:
+  # Long-lived branches: run CI on direct pushes (post-merge verification).
+  # Feature branches get CI via their PR (pull_request below), so a feature
+  # push with an open PR isn't double-run.
   push:
+    branches: [master, develop, dev_minor-update]
+  # Every PR, regardless of base branch — this is what satisfies the required
+  # status checks on the protected branches. Keep it unconditional.
   pull_request:
 
 jobs:


### PR DESCRIPTION
## 目的
PR運用への移行に伴い、CIの `on:` を整理して二重実行を解消する。

## 変更
```yaml
on:
  push:
    branches: [master, develop, dev_minor-update]
  pull_request:
```
- 機能ブランチへのpushはCIを起動せず、**PR経由でのみ**CI実行 → 二重起動を解消
- 長命3ブランチ（master/develop/dev_minor-update）への直接push時はCI実行（合流後検証）
- `pull_request` は無条件のまま維持 → 保護ブランチの必須チェック（unit-tests / e2e）がPRで必ず報告される

## 背景
master / develop / dev_minor-update にブランチ保護（PR必須 + CI2本通過必須 + enforce_admins）を設定済み。本PRはその新運用の最初の実地テストを兼ねる。

機能面の変更なし（CIトリガのスコープのみ）。